### PR TITLE
feat: add ghq alias and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# dotfiles
+
+## ビルド・適用
+
+```bash
+# PATHにnixがない環境では先頭にexportが必要
+export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+
+# home-managerの適用
+nix run home-manager -- -f ~/dotfiles/home.nix switch
+```
+
+## 構成
+
+- `home.nix` - エントリポイント
+- `modules/programs/` - プログラムごとの設定 (git等)
+- `modules/settings/zsh-config.nix` - zshのalias, PATH, secrets
+
+## シェルエイリアスの追加
+
+`modules/settings/zsh-config.nix` の `aliases` ブロックに追記する。

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -26,6 +26,7 @@
 
     ignores = [
       ".DS_Store"
+      "environment.toml"
       "*.swp"
     ];
   };

--- a/modules/settings/zsh-config.nix
+++ b/modules/settings/zsh-config.nix
@@ -2,9 +2,9 @@
   aliases = ''
     alias c="code ."
     alias rel="source ~/.zshrc"
+    alias ghq="gh q"
 
-    watch() { claude "/watch-pr $1"; }
-    review() { claude "/review-pr $1"; }
+    review() { claude "/review-flow $1"; }
     current() { claude "/current-pr gh pr view | head -n 150 => $(gh pr view | head -n 150), gh pr diff | head -n 50 => $(gh pr diff | head -n 50) $1"; }
   '';
 


### PR DESCRIPTION
## Summary
- `ghq` → `gh q` のシェルエイリアスを追加
- CLAUDE.md を新規作成（ビルド手順・構成情報）
- gitignore に environment.toml を追加

## Test plan
- [x] `nix run home-manager -- -f ~/dotfiles/home.nix switch` で適用確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント
  * リポジトリのセットアップ手順と全体的な設定構造を説明する新しいドキュメントを追加しました。

## Chores
  * バージョン管理システムの無視ファイルリストを拡張しました。
  * シェル環境に新しいエイリアスを追加し、既存の関数をワークフローの変更に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->