### PR TITLE
fix(cmux): disable sidebar blur for accurate Tokyo Night colors

### DIFF
--- a/modules/programs/cmux.nix
+++ b/modules/programs/cmux.nix
@@ -28,7 +28,7 @@
   # plist-only settings (not available in settings.json schema)
   home.activation.cmuxDefaults = ''
     /usr/bin/defaults write com.cmuxterm.app sidebarBlendMode -string "withinWindow"
-    /usr/bin/defaults write com.cmuxterm.app sidebarBlurOpacity -float 1
+    /usr/bin/defaults write com.cmuxterm.app sidebarBlurOpacity -float 0
     /usr/bin/defaults write com.cmuxterm.app sidebarCornerRadius -float 0
     /usr/bin/defaults write com.cmuxterm.app sidebarMaterial -string "sidebar"
     /usr/bin/defaults write com.cmuxterm.app sidebarPreset -string "nativeSidebar"


### PR DESCRIPTION
## Summary
- `sidebarBlurOpacity` を 1 → 0 に変更
- macOSのサイドバーマテリアルブラーがTokyo Nightの背景色を薄めていた問題を修正

## Test plan
- [ ] cmux再起動後、サイドバーとターミナル背景色が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * macOS アプリケーションのサイドバー表示設定を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->