### PR TITLE
feat(aws): default profile to hikae-readonly, drop bootstrap

### DIFF
--- a/modules/programs/aws.nix
+++ b/modules/programs/aws.nix
@@ -1,25 +1,39 @@
 { config, ... }:
 
 # AWS CLI shared config.
-# Managed by home-manager so the MFA-required profile for hikae-admin is
-# reproducible. Credentials (~/.aws/credentials) stay unmanaged because they
-# hold long-term secrets.
+# Managed by home-manager so all profile definitions are reproducible.
+# Credentials (~/.aws/credentials) stay unmanaged because they hold
+# long-term secrets.
 #
-# How the MFA flow works:
+# Default profile holds the read-only daily driver. ~/.aws/credentials
+# must contain a [default] section with the access keys for the
+# `hikae-readonly` IAM user; until that placeholder is filled `aws` will
+# fail with NoCredentialProviders, which is intentional — never silently
+# fall back to admin credentials.
+#
+# Trade-off accepted vs. AssumeRole+MFA: zero re-auth friction for daily
+# CLI work at the cost of credential durability. Mitigations:
+#   * Read-only at the IAM level (defined in iac-aws/projects/shared/iam.tf).
+#   * Explicit Deny on secretsmanager:GetSecretValue / ssm:GetParameter* /
+#     kms:Decrypt so a leaked key cannot lift secrets.
+#   * Manual 365-day rotation tracked via the rotation_interval_days tag
+#     on the IAM user and Bitwarden item history.
+#
+# Write operations go through [profile hikae-admin-mfa]:
+#   * Long-term keys for hikae-admin live under [hikae-admin] in
+#     ~/.aws/credentials (NOT under [default] anymore — default is reserved
+#     for hikae-readonly).
 #   * `mfa_serial + source_profile` alone does NOT trigger sts:GetSessionToken
 #     in the AWS CLI; that combination is consumed only when paired with
-#     `role_arn` (assume-role flow). To get GetSessionToken from a plain
-#     IAM-user profile we use `credential_process`, which calls a small
-#     helper that prompts for the TOTP, caches the resulting session token,
-#     and emits it in the format AWS CLI / SDKs expect.
+#     `role_arn` (assume-role flow). credential_process is the workaround
+#     for a plain IAM-user MFA flow.
 #   * Bitwarden's WebAuthn passkey on the same user cannot drive
 #     sts:GetSessionToken from CLI; a separate virtual TOTP MFA must be
 #     enrolled in the IAM console. Its ARN is the `mfa_serial` below.
 #
 # Usage:
-#   $ terraform apply           # AWS_PROFILE is already hikae-admin-mfa,
-#                               # CLI prompts for the 6-digit TOTP only
-#                               # when the cached session expires.
+#   $ aws s3 ls                                    # default = hikae-readonly
+#   $ AWS_PROFILE=hikae-admin-mfa terraform apply  # write ops, prompts TOTP
 let
   mfaScript = "${config.home.homeDirectory}/.local/bin/aws-mfa-creds";
   mfaSerial = "arn:aws:iam::951872725222:mfa/hikae-admin-mfa";
@@ -34,13 +48,8 @@ in
     [default]
     region = ap-northeast-1
 
-    [profile bootstrap]
-    region = ap-northeast-1
-
     [profile hikae-admin-mfa]
     region             = ap-northeast-1
-    credential_process = ${mfaScript} ${mfaSerial} default 43200
+    credential_process = ${mfaScript} ${mfaSerial} hikae-admin 43200
   '';
-
-  home.sessionVariables.AWS_PROFILE = "hikae-admin-mfa";
 }


### PR DESCRIPTION
## Summary

Pair the new `hikae-readonly` IAM user (added in iac-aws) with the local AWS CLI config so daily \`aws\` commands run with read-only credentials by default.

## Changes

- `[default]` profile is now reserved for `hikae-readonly` access keys (placeholder until `~/.aws/credentials [default]` is populated; intentionally fails with NoCredentialProviders rather than silently falling back to admin)
- Drop legacy `[profile bootstrap]` (account-bootstrap user has been deleted upstream)
- `[profile hikae-admin-mfa]` `credential_process` now sources from `[hikae-admin]` in credentials (long-term admin keys moved out of `[default]`)
- Drop `home.sessionVariables.AWS_PROFILE` — rely on default profile fallback

## Trade-off

Long-lived access keys for daily reads vs. AssumeRole+MFA. Mitigations: ReadOnlyAccess + explicit Deny on \`secretsmanager:GetSecretValue\` / \`ssm:GetParameter*\` / \`kms:Decrypt\` (enforced in iac-aws), 365-day manual rotation tracked via Bitwarden + IAM tag.

## Verified

- \`aws sts get-caller-identity\` → \`user/hikae-readonly\`
- \`aws s3 ls\` → OK
- \`aws secretsmanager get-secret-value\` → \`AccessDenied\` (Deny policy effective)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ・アクセス管理の改善**
  * AWS設定の権限分離を強化しました。デフォルトプロファイルを読み取り専用に変更し、管理者権限が必要な操作は明示的なプロファイル指定が必須になります。
  * 環境変数による自動プロファイル設定を廃止し、認証情報処理フローを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->