### PR TITLE
feat(repro): substituter + determinism gate + sync metrics (Survivor #1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://nix-community.cachix.org
+            extra-trusted-public-keys = nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
       - name: Run formatter check
         timeout-minutes: 5
         run: nix build --no-link --print-build-logs '.#checks.x86_64-linux.formatting'
@@ -35,3 +37,18 @@ jobs:
           nix eval --raw '.#checks.x86_64-linux.build.drvPath'
           echo
           echo "evaluated successfully"
+      - name: Eval determinism gate
+        # drvPath が 2 回の eval で一致しない = builtins.currentTime / 環境依存 / IFD 等の
+        # impurity が紛れ込んだサイン。eval だけなので cheap。build determinism は別途。
+        timeout-minutes: 5
+        run: |
+          h1=$(nix eval --raw '.#checks.x86_64-linux.build.drvPath')
+          h2=$(nix eval --raw --no-eval-cache '.#checks.x86_64-linux.build.drvPath')
+          if [ "$h1" != "$h2" ]; then
+            echo "FAIL: drvPath differs across evaluations"
+            echo "  first:  $h1"
+            echo "  second: $h2"
+            exit 1
+          fi
+          echo "OK: drvPath stable across evaluations"
+          echo "  $h1"

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "hikae's dotfiles";
 
+  # Trusted substituter — home-manager activation を source build に落とさない。
+  # nix-community キーは upstream 配布値、追加時は CI 側でも extra_nix_config に反映。
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     home-manager = {

--- a/modules/programs/dotfiles-sync.nix
+++ b/modules/programs/dotfiles-sync.nix
@@ -6,6 +6,9 @@
 }:
 
 let
+  metricsDir = "${config.home.homeDirectory}/.cache/dotfiles-sync";
+  metricsFile = "${metricsDir}/metrics.jsonl";
+
   syncScript = pkgs.writeShellScript "dotfiles-sync" ''
     set -eu
     export PATH=${
@@ -16,29 +19,53 @@ let
       ]
     }:$PATH
 
+    mkdir -p "${metricsDir}"
+
+    started_at=$(date -u +%s)
+    head_before=""
+    head_after=""
+    outcome="error"
+
+    write_metric() {
+      ended_at=$(date -u +%s)
+      wall_s=$(( ended_at - started_at ))
+      ts=$(date -u +%FT%TZ)
+      printf '{"ts":"%s","outcome":"%s","wall_s":%d,"head_before":"%s","head_after":"%s"}\n' \
+        "$ts" "$outcome" "$wall_s" "$head_before" "$head_after" \
+        >>"${metricsFile}"
+    }
+    trap write_metric EXIT
+
     cd "$HOME/dotfiles"
+    head_before=$(git rev-parse HEAD 2>/dev/null || echo "")
+    head_after="$head_before"
 
     # main 以外で動いている時はスキップ (作業中ブランチを壊さない)
     branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
     if [ "$branch" != "main" ]; then
       echo "skip: not on main (current=$branch)"
+      outcome="skip-not-main"
       exit 0
     fi
 
     # dirty なら作業中なのでスキップ
     if ! git diff --quiet HEAD --; then
       echo "skip: dirty working tree"
+      outcome="skip-dirty"
       exit 0
     fi
 
     git fetch --quiet origin main
     if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)" ]; then
       echo "skip: already up to date"
+      outcome="skip-up-to-date"
       exit 0
     fi
 
     git pull --ff-only --quiet origin main
+    head_after=$(git rev-parse HEAD)
     nix run ".#homeConfigurations.hikae.activationPackage" --no-warn-dirty
+    outcome="activated"
   '';
 in
 {


### PR DESCRIPTION
## Survivor #1 — 計測駆動 Reproducibility パイプ (MVP slice)

ideation: docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md (Survivor #1)

### この PR の射程
ideation 全体の "計測駆動 Reproducibility パイプ" は cachix substituter / determinism gate / closure-size drift snapshot / activation metrics の 4 点セット。本 PR はその MVP として substituter / determinism gate / activation metrics の 3 点をまとめて入れる (closure-size snapshot は別 repo を要するので次 PR)。

### Changes

- **`flake.nix`**: `nixConfig.extra-substituters` に `https://nix-community.cachix.org` と公開鍵を追加。home-manager activation の source build を避けるための pre-fetch 用キャッシュ。
- **`.github/workflows/ci.yml`**: install-nix-action にも同じ substituter を渡し、CI の home-manager eval を高速化。さらに `Eval determinism gate` ステップを追加し、`--no-eval-cache` で 2 回 eval した drvPath を比較。impurity (`builtins.currentTime` / 環境依存 / IFD) が混ざった瞬間に CI fail。
- **`modules/programs/dotfiles-sync.nix`**: trap で 1 行 JSONL を `~/.cache/dotfiles-sync/metrics.jsonl` に追記。`ts / outcome / wall_s / head_before / head_after` を記録し、09:00 daily sync の挙動を初めて事後解析可能にする。outcome は `skip-not-main / skip-dirty / skip-up-to-date / activated / error` で正常 / 失敗を分離。

### Notes

- `nixConfig` の substituter は単一ユーザー nix では `trusted-users = @admin` (or 該当ユーザー) を nix.conf に追加した状態で初めて有効化される。未追加なら daemon が無視するだけで害はない。
- determinism gate は eval 段階の同一性のみを保証 (build determinism は別途、今回は CI 完全 build を諦めている前提を維持)。
- metrics.jsonl はローテートしていない。追記のみ。週次オーダーで GB に達することはない (1 行 ≈100 bytes × 365)。
