### PR TITLE
feat(ledger): introduce package ledger with metadata + audit app (Survivor #2)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,49 @@
             "*.json"
           ];
         };
+
+      # Package ledger audit script (Survivor #2 MVP).
+      # 各 system の pkgs から registry を組み立て、purpose 別の集計と
+      # expires 期限切れエントリを STDOUT に出力する。
+      auditAppFor =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system overlays;
+            config.allowUnfree = true;
+          };
+          ledger = import ./lib/ledger.nix {
+            inherit pkgs;
+            lib = pkgs.lib;
+          };
+          registry = import ./lib/package-registry.nix {
+            inherit pkgs;
+            lib = pkgs.lib;
+          };
+          payload = ledger.toJSON registry.all;
+          script = pkgs.writeShellScriptBin "audit" ''
+            set -eu
+            JSON=${pkgs.lib.escapeShellArg payload}
+            echo "## Package Ledger ($(${pkgs.coreutils}/bin/date -u +%FT%TZ))"
+            echo ""
+            echo "Total entries: $(printf '%s' "$JSON" | ${pkgs.jq}/bin/jq 'length')"
+            echo ""
+            echo "By purpose:"
+            printf '%s' "$JSON" | ${pkgs.jq}/bin/jq -r 'group_by(.purpose) | .[] | "  \(.[0].purpose)\t\(length)"'
+            echo ""
+            echo "Entries (purpose / source / expires / name / reason):"
+            printf '%s' "$JSON" \
+              | ${pkgs.jq}/bin/jq -r 'sort_by(.purpose, .name) | .[] | [.purpose, .source, (.expires // "-"), .name, .reason] | @tsv' \
+              | ${pkgs.coreutils}/bin/column -t -s "$(printf '\t')"
+            echo ""
+            EXPIRED=$(printf '%s' "$JSON" | ${pkgs.jq}/bin/jq '[.[] | select(.expires != null)] | length')
+            echo "Entries with expires set: $EXPIRED"
+          '';
+        in
+        {
+          type = "app";
+          program = "${script}/bin/audit";
+        };
     in
     {
       homeConfigurations."hikae" = forSystem "aarch64-darwin";
@@ -70,6 +113,10 @@
       formatter = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-linux" ] (
         system: (treefmtFor system).config.build.wrapper
       );
+
+      apps = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-linux" ] (system: {
+        audit = auditAppFor system;
+      });
 
       # CI (ubuntu) での検証用
       checks.x86_64-linux = {

--- a/lib/ledger.nix
+++ b/lib/ledger.nix
@@ -1,0 +1,76 @@
+# Package Ledger — 期限付き複式記帳化のデータ層
+#
+# 目的: home.packages / Brewfile に並ぶ各エントリに「出所 (source) / 用途 (purpose) /
+# 期限 (expires) / 採用理由 (reason)」を付与し、棚卸しを機械化可能にする。
+# 詳細: docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md (Survivor #2)
+#
+# 利用側は `mkEntry` で 1 エントリを宣言し、`pkgsOf` でビルド可能な package list、
+# `metaOf` で audit 用 metadata list を取り出す。
+{
+  pkgs,
+  lib,
+}:
+
+let
+  # 用途タクソノミ (固定 7 値)。新カテゴリ追加は ADR を要求する想定。
+  purposes = [
+    "build" # コンパイル・ビルド・CI・テスト基盤
+    "edit" # 主要エディタ・コーディング体験を構成
+    "ops" # クラウド・インフラ・DB 運用
+    "comm" # 連絡・ブラウザ・チャット
+    "observe" # 監視・ログ・デバッグ
+    "play" # 実験・AI・遊び
+    "util" # 横断的に使う小道具
+  ];
+
+  validPurpose = p: builtins.elem p purposes;
+
+  mkEntry =
+    {
+      pkg,
+      purpose,
+      source ? "nixpkgs",
+      expires ? null,
+      reason ? "",
+    }:
+    assert lib.assertMsg (validPurpose purpose)
+      "ledger.mkEntry: unknown purpose '${purpose}' (allowed: ${lib.concatStringsSep ", " purposes})";
+    {
+      inherit
+        pkg
+        purpose
+        source
+        expires
+        reason
+        ;
+      name = pkg.pname or pkg.name or "?";
+    };
+
+  # entries (list of mkEntry result) → list of derivations
+  pkgsOf = entries: map (e: e.pkg) entries;
+
+  # entries → list of plain-attrset metadata (audit 用、derivation を含めない)
+  metaOf =
+    entries:
+    map (e: {
+      inherit (e)
+        name
+        purpose
+        source
+        expires
+        reason
+        ;
+    }) entries;
+
+  # JSON 表現 (apps.audit が jq に流すため)
+  toJSON = entries: builtins.toJSON (metaOf entries);
+in
+{
+  inherit
+    mkEntry
+    pkgsOf
+    metaOf
+    toJSON
+    purposes
+    ;
+}

--- a/lib/package-registry.nix
+++ b/lib/package-registry.nix
@@ -1,0 +1,381 @@
+# Package Ledger — single source of truth
+#
+# 全エントリをここに集中させ、`modules/packages.nix` は home.packages 用に
+# pkg だけを抽出、`flake.nix` の `apps.<system>.audit` は metadata を抽出して
+# 整形表示する。両者で重複を持たないために registry を 1 ファイルに切り出している。
+{
+  pkgs,
+  lib,
+}:
+
+let
+  ledger = import ./ledger.nix { inherit pkgs lib; };
+  inherit (ledger) mkEntry;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
+
+  cross = [
+    # Nix runtime / package mgmt
+    (mkEntry {
+      pkg = pkgs.cachix;
+      purpose = "build";
+      reason = "binary cache CLI";
+    })
+    (mkEntry {
+      pkg = pkgs.pinentry-curses;
+      purpose = "ops";
+      reason = "GnuPG passphrase prompt";
+    })
+    (mkEntry {
+      pkg = pkgs.lato;
+      purpose = "edit";
+      reason = "fallback font for terminals";
+    })
+    (mkEntry {
+      pkg = pkgs.mise;
+      purpose = "build";
+      reason = "per-project tool versions";
+    })
+    (mkEntry {
+      pkg = pkgs.devenv;
+      purpose = "build";
+      reason = "dev shells per project";
+    })
+
+    # Devflow
+    (mkEntry {
+      pkg = pkgs.gh;
+      purpose = "edit";
+      reason = "GitHub CLI / PR ops";
+    })
+    (mkEntry {
+      pkg = pkgs.ripgrep;
+      purpose = "util";
+      reason = "primary code search";
+    })
+    (mkEntry {
+      pkg = pkgs.fd;
+      purpose = "util";
+      reason = "primary find replacement";
+    })
+    (mkEntry {
+      pkg = pkgs.gitleaks;
+      purpose = "ops";
+      reason = "secret scanning hook";
+    })
+    (mkEntry {
+      pkg = pkgs.pinact;
+      purpose = "ops";
+      reason = "GitHub Actions SHA pin";
+    })
+
+    # Cloud / Infra / Security
+    (mkEntry {
+      pkg = pkgs.awscli2;
+      purpose = "ops";
+      reason = "AWS CLI";
+    })
+    (mkEntry {
+      pkg = pkgs.cloudflared;
+      purpose = "ops";
+      reason = "Cloudflare Tunnel client";
+    })
+    (mkEntry {
+      pkg = pkgs.flyctl;
+      purpose = "ops";
+      reason = "Fly.io CLI";
+    })
+    (mkEntry {
+      pkg = pkgs.trivy;
+      purpose = "ops";
+      reason = "container/IaC vulnerability scan";
+    })
+    (mkEntry {
+      pkg = pkgs.trufflehog;
+      purpose = "ops";
+      reason = "secret scanner (audit-only)";
+    })
+    (mkEntry {
+      pkg = pkgs.sops;
+      purpose = "ops";
+      reason = "encrypted config files";
+    })
+
+    # Container / Virt
+    (mkEntry {
+      pkg = pkgs.docker-buildx;
+      purpose = "build";
+      reason = "multi-arch container build";
+    })
+    (mkEntry {
+      pkg = pkgs.podman;
+      purpose = "build";
+      reason = "rootless container runtime";
+    })
+    (mkEntry {
+      pkg = pkgs.qemu;
+      purpose = "build";
+      reason = "cross-arch emulation backend";
+    })
+    (mkEntry {
+      pkg = pkgs.lima;
+      purpose = "build";
+      reason = "macOS Linux VM";
+    })
+    (mkEntry {
+      pkg = pkgs.devcontainer;
+      purpose = "build";
+      reason = "devcontainer CLI";
+    })
+
+    # Languages / build
+    (mkEntry {
+      pkg = pkgs.cmake;
+      purpose = "build";
+      reason = "C/C++ build system";
+    })
+    (mkEntry {
+      pkg = pkgs.automake;
+      purpose = "build";
+      reason = "autotools build";
+    })
+    (mkEntry {
+      pkg = pkgs.pkg-config;
+      purpose = "build";
+      reason = "library probe";
+    })
+    (mkEntry {
+      pkg = pkgs.golangci-lint;
+      purpose = "build";
+      reason = "Go meta-linter";
+    })
+    (mkEntry {
+      pkg = pkgs.ast-grep;
+      purpose = "build";
+      reason = "syntactic codemod";
+    })
+    (mkEntry {
+      pkg = pkgs.tree-sitter;
+      purpose = "build";
+      reason = "parser generator";
+    })
+    (mkEntry {
+      pkg = pkgs.wasmtime;
+      purpose = "build";
+      reason = "WASM runtime";
+    })
+    (mkEntry {
+      pkg = pkgs.sccache;
+      purpose = "build";
+      reason = "rust compile cache";
+    })
+    (mkEntry {
+      pkg = pkgs.sqlc;
+      purpose = "build";
+      reason = "SQL -> Go codegen";
+    })
+    (mkEntry {
+      pkg = pkgs.dotenvx;
+      purpose = "ops";
+      reason = "encrypted .env loader";
+    })
+
+    # DB / data
+    (mkEntry {
+      pkg = pkgs.duckdb;
+      purpose = "ops";
+      reason = "embedded analytics DB";
+    })
+    (mkEntry {
+      pkg = pkgs.postgresql_14;
+      purpose = "ops";
+      reason = "local Postgres for projects";
+    })
+    (mkEntry {
+      pkg = pkgs.redis;
+      purpose = "ops";
+      reason = "local Redis for projects";
+    })
+
+    # CLI utils
+    (mkEntry {
+      pkg = pkgs.coreutils;
+      purpose = "util";
+      reason = "GNU coreutils on Darwin";
+    })
+    (mkEntry {
+      pkg = pkgs.tree;
+      purpose = "util";
+      reason = "directory listing";
+    })
+    (mkEntry {
+      pkg = pkgs.htop;
+      purpose = "observe";
+      reason = "process monitor";
+    })
+    (mkEntry {
+      pkg = pkgs.jq;
+      purpose = "util";
+      reason = "JSON processor";
+    })
+    (mkEntry {
+      pkg = pkgs.jj;
+      purpose = "edit";
+      reason = "Jujutsu VCS";
+    })
+    (mkEntry {
+      pkg = pkgs.just;
+      purpose = "build";
+      reason = "task runner";
+    })
+    (mkEntry {
+      pkg = pkgs.nushell;
+      purpose = "util";
+      reason = "structured-data shell";
+    })
+    (mkEntry {
+      pkg = pkgs.pueue;
+      purpose = "ops";
+      reason = "background task queue";
+    })
+    (mkEntry {
+      pkg = pkgs.rclone;
+      purpose = "ops";
+      reason = "cloud storage sync";
+    })
+    (mkEntry {
+      pkg = pkgs.git-lfs;
+      purpose = "edit";
+      reason = "Git LFS";
+    })
+    (mkEntry {
+      pkg = pkgs.inetutils;
+      purpose = "util";
+      reason = "telnet/ftp on Darwin";
+    })
+    (mkEntry {
+      pkg = pkgs.sshpass;
+      purpose = "ops";
+      reason = "non-interactive SSH";
+    })
+    (mkEntry {
+      pkg = pkgs.nmap;
+      purpose = "ops";
+      reason = "network probe";
+    })
+    (mkEntry {
+      pkg = pkgs.ngrok;
+      purpose = "ops";
+      reason = "tunnel localhost";
+    })
+    (mkEntry {
+      pkg = pkgs.mitmproxy;
+      purpose = "observe";
+      reason = "HTTPS interception debug";
+    })
+    (mkEntry {
+      pkg = pkgs.rtk;
+      purpose = "play";
+      reason = "LLM token reduction proxy";
+    })
+    (mkEntry {
+      pkg = pkgs.vhs;
+      purpose = "play";
+      reason = "terminal recording";
+    })
+
+    # Misc
+    (mkEntry {
+      pkg = pkgs.ollama;
+      purpose = "play";
+      reason = "local LLM serving";
+    })
+
+    # GUI applications (cask 移行・darwin 対応確認済み)
+    (mkEntry {
+      pkg = pkgs.slack;
+      purpose = "comm";
+      reason = "team chat";
+    })
+    (mkEntry {
+      pkg = pkgs.discord;
+      purpose = "comm";
+      reason = "community chat";
+    })
+    (mkEntry {
+      pkg = pkgs.google-chrome;
+      purpose = "comm";
+      reason = "browser fallback";
+    })
+
+    # build / lib deps (brew leaves に出ていた一般ツール)
+    (mkEntry {
+      pkg = pkgs.ffmpeg;
+      purpose = "util";
+      reason = "video/audio encoder";
+    })
+    (mkEntry {
+      pkg = pkgs.gnupg;
+      purpose = "ops";
+      reason = "GnuPG";
+    })
+    (mkEntry {
+      pkg = pkgs.librsvg;
+      purpose = "build";
+      reason = "SVG rasterizer for build deps";
+    })
+    (mkEntry {
+      pkg = pkgs.protobuf;
+      purpose = "build";
+      reason = "protoc";
+    })
+    (mkEntry {
+      pkg = pkgs.autoconf;
+      purpose = "build";
+      reason = "autotools";
+    })
+    (mkEntry {
+      pkg = pkgs.gts;
+      purpose = "build";
+      reason = "GNU triangulated surface lib";
+    })
+  ];
+
+  # darwin でしかビルドできない / linux 等価が無いもの。
+  # CI は x86_64-linux で評価するためここを越境させると build 失敗。
+  darwinOnly = lib.optionals isDarwin [
+    (mkEntry {
+      pkg = pkgs.cocoapods;
+      purpose = "build";
+      reason = "iOS native dep manager";
+    })
+    (mkEntry {
+      pkg = pkgs.mas;
+      purpose = "ops";
+      reason = "Mac App Store CLI";
+    })
+    (mkEntry {
+      pkg = pkgs.duti;
+      purpose = "ops";
+      reason = "default app association";
+    })
+    (mkEntry {
+      pkg = pkgs.terminal-notifier;
+      purpose = "util";
+      reason = "macOS notification trigger";
+    })
+    (mkEntry {
+      pkg = pkgs.iproute2mac;
+      purpose = "ops";
+      reason = "ip(8) on Darwin";
+    })
+    (mkEntry {
+      pkg = pkgs.raycast;
+      purpose = "edit";
+      reason = "launcher / extension host";
+    })
+  ];
+in
+{
+  inherit cross darwinOnly;
+  all = cross ++ darwinOnly;
+}

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -1,109 +1,14 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  dotfilesPath,
+  ...
+}:
 
 let
-  inherit (pkgs.stdenv.hostPlatform) isDarwin;
-
-  # darwin でしかビルドできない / linux 等価が無いもの。
-  # CI は x86_64-linux で評価するためここを越境させると build 失敗。
-  darwinOnly = lib.optionals isDarwin [
-    pkgs.cocoapods
-    pkgs.mas
-    pkgs.duti
-    pkgs.terminal-notifier
-    pkgs.iproute2mac
-    pkgs.raycast
-  ];
-
-  cross = [
-    # Nix runtime / package mgmt
-    pkgs.cachix
-    pkgs.pinentry-curses
-    pkgs.lato
-    pkgs.mise
-    pkgs.devenv
-
-    # Devflow
-    pkgs.gh
-    pkgs.ripgrep
-    pkgs.fd
-    pkgs.gitleaks
-    pkgs.pinact
-
-    # Cloud / Infra / Security
-    pkgs.awscli2
-    pkgs.cloudflared
-    pkgs.flyctl
-    # pkgs.checkov: nixpkgs ≥ 2026-04-27 で python313Packages.av の
-    # pythonImportsCheck が aarch64-darwin で SIGKILL → Brewfile に逃がす
-    pkgs.trivy
-    pkgs.trufflehog
-    pkgs.sops
-
-    # Container / Virt
-    pkgs.docker-buildx
-    pkgs.podman
-    pkgs.qemu
-    pkgs.lima
-    pkgs.devcontainer
-
-    # Languages / build
-    pkgs.cmake
-    pkgs.automake
-    pkgs.pkg-config
-    pkgs.golangci-lint
-    pkgs.ast-grep
-    pkgs.tree-sitter
-    pkgs.wasmtime
-    pkgs.sccache
-    pkgs.sqlc
-    pkgs.dotenvx
-
-    # DB / data
-    pkgs.duckdb
-    pkgs.postgresql_14
-    pkgs.redis
-
-    # CLI utils
-    pkgs.coreutils
-    pkgs.tree
-    pkgs.htop
-    pkgs.jq
-    pkgs.jj
-    pkgs.just
-    pkgs.nushell
-    pkgs.pueue
-    pkgs.rclone
-    pkgs.git-lfs
-    pkgs.inetutils
-    pkgs.sshpass
-    pkgs.nmap
-    pkgs.ngrok
-    pkgs.mitmproxy
-    pkgs.rtk
-    pkgs.vhs
-
-    # Misc
-    pkgs.ollama
-
-    # Mobile dev (cask 移行)
-    # pkgs.android-tools
-
-    # GUI applications (cask 移行・darwin 対応確認済み)
-    # pkgs.vscode
-    # pkgs.code-cursor
-    pkgs.slack
-    pkgs.discord
-    pkgs.google-chrome
-
-    # build / lib deps (brew leaves に出ていた一般ツール)
-    pkgs.ffmpeg
-    pkgs.gnupg
-    pkgs.librsvg
-    pkgs.protobuf
-    pkgs.autoconf
-    pkgs.gts
-  ];
+  ledger = import "${dotfilesPath}/lib/ledger.nix" { inherit pkgs lib; };
+  registry = import "${dotfilesPath}/lib/package-registry.nix" { inherit pkgs lib; };
 in
 {
-  home.packages = cross ++ darwinOnly;
+  home.packages = ledger.pkgsOf registry.all;
 }


### PR DESCRIPTION
## Survivor #2 — Package Ledger (MVP slice)

ideation: docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md (Survivor #2)

### この PR の射程
ideation の "Package Ledger" は (a) metadata 層 (source/purpose/expires/reason) (b) audit/可視化 (c) 30/90 日未使用検出 + launchd weekly sweep (d) Brewfile linting (no `vscode "..."`) (e) `nix-store --query --references` 重複検出、の 5 段。本 PR は (a)+(b) の MVP まで。残り (c)–(e) は次 PR。

### Changes

- **`lib/ledger.nix`**: 用途タクソノミ (`build` / `edit` / `ops` / `comm` / `observe` / `play` / `util` の 7 値固定) と `mkEntry` / `pkgsOf` / `metaOf` / `toJSON` 助手。`mkEntry` は purpose 値域を `assert` で eval 時に検証。新カテゴリ追加は ADR を要求する想定の閉じた語彙。
- **`lib/package-registry.nix`**: 全 home.packages エントリの single source of truth。`modules/packages.nix` と `apps.<system>.audit` が同じデータを参照する。
- **`modules/packages.nix`**: registry を import し、`ledger.pkgsOf registry.all` を `home.packages` に渡すだけに圧縮 (従来 100+ 行 → 9 行)。
- **`flake.nix`**: `apps.<system>.audit` を追加。`nix run .#audit` で `## Package Ledger (timestamp)`, purpose 別集計, 全エントリ表 (purpose / source / expires / name / reason)、`Entries with expires set: N` を column 整形で STDOUT に出力。

### Notes / 既知の限界

- `expires` フィールドは現状全 entry で `null` (登録のみ・enforcement なし)。次 PR で launchd weekly sweep が `expires < today` なら fail / `gh issue create --label prune-candidate` を発火させる。
- `source` も全 entry が `"nixpkgs"`。Brewfile / mas / cargo / npm 経由のエントリも同じ registry に収容するのは別 PR (Brewfile parser が必要)。
- 用途語彙の妥当性は数ヶ月運用してから ADR で確定する想定。当面は 7 値で困ったら追加。
- `nix run .#audit` は `coreutils` の `column` を経由する。Darwin 標準 `column` ではなく nix 提供版 (BSD column) で TSV 整形する。

### 検証
- `nix flake check --accept-flake-config` 通過 (apps.aarch64-darwin.audit に `meta` がない warning のみ、評価は OK)
- `nix fmt` で全 23 ファイル treefmt 整形済
