### PR TITLE
fix(ledger): use gawk for audit table (column is not in coreutils)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,9 +105,10 @@
             printf '%s' "$JSON" | ${pkgs.jq}/bin/jq -r 'group_by(.purpose) | .[] | "  \(.[0].purpose)\t\(length)"'
             echo ""
             echo "Entries (purpose / source / expires / name / reason):"
+            # awk で列整形 (column は coreutils に無く util-linux 依存になるため避ける)
             printf '%s' "$JSON" \
               | ${pkgs.jq}/bin/jq -r 'sort_by(.purpose, .name) | .[] | [.purpose, .source, (.expires // "-"), .name, .reason] | @tsv' \
-              | ${pkgs.coreutils}/bin/column -t -s "$(printf '\t')"
+              | ${pkgs.gawk}/bin/awk -F'\t' '{ printf "  %-8s %-9s %-11s %-32s %s\n", $1, $2, $3, $4, $5 }'
             echo ""
             EXPIRED=$(printf '%s' "$JSON" | ${pkgs.jq}/bin/jq '[.[] | select(.expires != null)] | length')
             echo "Entries with expires set: $EXPIRED"


### PR DESCRIPTION
Survivor #2 PR #13 follow-up. `column` is from util-linux, not coreutils — `${pkgs.coreutils}/bin/column` fails at runtime with no-such-file. Switched to `pkgs.gawk` printf for column alignment. Confirmed via `nix run .#audit` (67 entries listed correctly).