### PR TITLE
fix(git): manage gh credential helper declaratively, purge stale ~/.gitconfig

### DIFF
--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -20,6 +20,8 @@ let
       exec "$local_hook" "$@"
     fi
   '';
+
+  ghCredentialHelper = "!${pkgs.gh}/bin/gh auth git-credential";
 in
 {
   programs.git = {
@@ -42,6 +44,15 @@ in
       pull.rebase = true;
       fetch.prune = true;
 
+      # gh CLI credential helper を nix-store path で固定。
+      # 旧 ~/.gitconfig には /opt/homebrew/bin/gh が hardcode されており
+      # gh が nix-profile に移った時点で push が device-not-configured で fail していた。
+      # 旧設定は home.activation.purgeStaleGhCredentialHelper で unset する。
+      credential = {
+        "https://github.com".helper = ghCredentialHelper;
+        "https://gist.github.com".helper = ghCredentialHelper;
+      };
+
       alias = {
         st = "status -sb";
         co = "checkout";
@@ -59,4 +70,25 @@ in
   };
 
   xdg.configFile."git/hooks/pre-commit".source = preCommit;
+
+  # gh auth setup-git が ~/.gitconfig に書いた絶対パス helper を撤去。
+  # ~/.gitconfig の設定は ~/.config/git/config を上書きするため、
+  # この unset を行わないと HM 管理側の credential helper は効かない。
+  # 冪等: 対象キーが無ければ no-op で抜ける。
+  home.activation.purgeStaleGhCredentialHelper = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    gitconfig="$HOME/.gitconfig"
+    [ -f "$gitconfig" ] || exit 0
+    for host in github.com gist.github.com; do
+      key="credential.https://$host.helper"
+      if ${pkgs.git}/bin/git config --file "$gitconfig" --get-all "$key" >/dev/null 2>&1; then
+        $DRY_RUN_CMD ${pkgs.git}/bin/git config --file "$gitconfig" --unset-all "$key" || true
+      fi
+      # 残った空の [credential "https://..."] section を削除
+      if ${pkgs.git}/bin/git config --file "$gitconfig" --get-regexp "^credential\\.https://$host\\." >/dev/null 2>&1; then
+        : # まだ他 key が残っているならセクションは残す
+      else
+        $DRY_RUN_CMD ${pkgs.git}/bin/git config --file "$gitconfig" --remove-section "credential.https://$host" 2>/dev/null || true
+      fi
+    done
+  '';
 }


### PR DESCRIPTION
## 修正

### 問題
`~/.gitconfig:16-21` に `gh auth setup-git` が書いた絶対パスの helper:

```
[credential "https://github.com"]
	helper = 
	helper = !/opt/homebrew/bin/gh auth git-credential
[credential "https://gist.github.com"]
	helper = 
	helper = !/opt/homebrew/bin/gh auth git-credential
```

gh CLI が brew → nix-profile に移行した時点で `/opt/homebrew/bin/gh` が無くなり、`git push` が以下で fail していた:

```
/opt/homebrew/bin/gh auth git-credential get: line 1: /opt/homebrew/bin/gh: No such file or directory
fatal: could not read Username for 'https://github.com': Device not configured
```

ce-ideate 並列バッチ作業中に踏み、SSH push で迂回したが declarative 修正が必要。

### 修正
1. `modules/programs/git.nix` で `programs.git.settings.credential."https://github.com".helper` (および gist) を `!${pkgs.gh}/bin/gh auth git-credential` で登録 → HM が `~/.config/git/config` に書き、`pkgs.gh` の store path に追従。
2. `home.activation.purgeStaleGhCredentialHelper` で `~/.gitconfig` の `credential.https://<host>.helper` を `--unset-all` し、残ったセクションが空なら `--remove-section`。冪等。

### 検証
- `nix flake check --accept-flake-config` 通過
- 既存の SSH 設定 (commit signing 等) は無変更

### Notes
- HM activation 1 回で旧 hardcode が消える。`activationPackage` を実行すれば即解消。
- gh upgrade で nix-store path が変わっても再 activation で追従するため再固定不要。
- 新規マシンでは `gh auth login` だけで OK (`gh auth setup-git` 不要)。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHubおよびGistへのGit認証情報ヘルパーをNix設定により管理

* **バグ修正**
  * gitconfigに残された古い認証ヘルパー設定を自動的に検出して削除、設定ファイルをクリーンアップ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->