### PR TITLE
feat(lint): add nix run .#lint for deadnix + shellcheck (Survivor #4 MVP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run formatter check
         timeout-minutes: 5
         run: nix build --no-link --print-build-logs '.#checks.x86_64-linux.formatting'
+      - name: Run linters (deadnix + shellcheck)
+        timeout-minutes: 5
+        run: nix run --accept-flake-config '.#lint'
       - name: Evaluate home-manager configuration
         # 完全ビルドは crush 等の go テスト走行で 25min を超える上、
         # 実際にデプロイされるのは aarch64-darwin。eval だけでも cocoapods

--- a/flake.nix
+++ b/flake.nix
@@ -64,9 +64,11 @@
         system:
         treefmt-nix.lib.evalModule nixpkgs.legacyPackages.${system} {
           projectRootFile = "flake.nix";
-          programs.nixfmt.enable = true;
-          programs.prettier.enable = true;
-          programs.shfmt.enable = true;
+          programs = {
+            nixfmt.enable = true;
+            prettier.enable = true;
+            shfmt.enable = true;
+          };
           settings.formatter.prettier.includes = [
             "*.md"
             "*.yaml"
@@ -78,6 +80,45 @@
       # Package ledger audit script (Survivor #2 MVP).
       # 各 system の pkgs から registry を組み立て、purpose 別の集計と
       # expires 期限切れエントリを STDOUT に出力する。
+      # Static analysis aggregator (Survivor #4 MVP).
+      # treefmt は formatter のみ。lint (statix / deadnix / shellcheck) は
+      # 別 entrypoint に集約し、CI と手元の両方から `nix run .#lint` で叩ける。
+      lintAppFor =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system overlays;
+            config.allowUnfree = true;
+          };
+          script = pkgs.writeShellScriptBin "lint" ''
+            set -eu
+            root="''${PRJ_ROOT:-$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}"
+            cd "$root"
+
+            # NOTE: statix は将来追加。現状は indented-string 内の Nix
+            # interpolation を W04 として誤検出するため、別 PR で
+            # statix.toml に disabled_lints を整備してから配線する。
+
+            echo "==> deadnix"
+            ${pkgs.deadnix}/bin/deadnix --fail .
+
+            echo "==> shellcheck (tracked *.sh)"
+            shfiles=$(${pkgs.git}/bin/git ls-files '*.sh' 2>/dev/null || true)
+            if [ -n "$shfiles" ]; then
+              # shellcheck disable=SC2086
+              ${pkgs.shellcheck}/bin/shellcheck $shfiles
+            else
+              echo "  (no *.sh tracked)"
+            fi
+
+            echo "OK: all linters passed"
+          '';
+        in
+        {
+          type = "app";
+          program = "${script}/bin/lint";
+        };
+
       auditAppFor =
         system:
         let
@@ -85,10 +126,7 @@
             inherit system overlays;
             config.allowUnfree = true;
           };
-          ledger = import ./lib/ledger.nix {
-            inherit pkgs;
-            lib = pkgs.lib;
-          };
+          ledger = import ./lib/ledger.nix { lib = pkgs.lib; };
           registry = import ./lib/package-registry.nix {
             inherit pkgs;
             lib = pkgs.lib;
@@ -128,6 +166,7 @@
 
       apps = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-linux" ] (system: {
         audit = auditAppFor system;
+        lint = lintAppFor system;
       });
 
       # CI (ubuntu) での検証用

--- a/lib/ledger.nix
+++ b/lib/ledger.nix
@@ -6,10 +6,7 @@
 #
 # 利用側は `mkEntry` で 1 エントリを宣言し、`pkgsOf` でビルド可能な package list、
 # `metaOf` で audit 用 metadata list を取り出す。
-{
-  pkgs,
-  lib,
-}:
+{ lib }:
 
 let
   # 用途タクソノミ (固定 7 値)。新カテゴリ追加は ADR を要求する想定。

--- a/lib/package-registry.nix
+++ b/lib/package-registry.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  ledger = import ./ledger.nix { inherit pkgs lib; };
+  ledger = import ./ledger.nix { inherit lib; };
   inherit (ledger) mkEntry;
   inherit (pkgs.stdenv.hostPlatform) isDarwin;
 

--- a/modules/packages.nix
+++ b/modules/packages.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  ledger = import "${dotfilesPath}/lib/ledger.nix" { inherit pkgs lib; };
+  ledger = import "${dotfilesPath}/lib/ledger.nix" { inherit lib; };
   registry = import "${dotfilesPath}/lib/package-registry.nix" { inherit pkgs lib; };
 in
 {

--- a/modules/programs/aws.nix
+++ b/modules/programs/aws.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 
 # AWS CLI shared config.
 # Managed by home-manager so all profile definitions are reproducible.

--- a/modules/programs/zsh.nix
+++ b/modules/programs/zsh.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+_:
 
 {
   programs.zsh = {


### PR DESCRIPTION
## Survivor #4 — Pre-commit Flake Module + treefmt 拡張 (lint MVP slice)

ideation: docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md (Survivor #4)

### この PR の射程
ideation 全体の Survivor #4 は (a) lint アプリ集約 (b) treefmt の polyglot 拡張 (c) AGENTS.md auto-gen (d) 他 repo へ flake output で配布、の 4 段。本 PR は (a) のみ。残りは順次。

### Changes

- **`flake.nix`**: `apps.<system>.lint` を追加。`deadnix --fail .` と `shellcheck` (`git ls-files '*.sh'`) を順次実行し、いずれか fail で exit 1。treefmt config を `programs = { ... }` 形式に統合 (statix W20 対応の前哨)。
- **`.github/workflows/ci.yml`**: "Run linters" ステップを追加。CI で dead nix / shell 混入を止める。
- **`modules/programs/aws.nix`, `modules/programs/zsh.nix`**: deadnix が指摘した未使用 lambda pattern (`{ ... }:` / `{ config, ... }:`) を `_:` に置換。
- **`lib/ledger.nix`**: `pkgs` 引数が未使用だったため drop。caller 3 箇所 (`flake.nix`, `lib/package-registry.nix`, `modules/packages.nix`) を `lib` 単独引数に追従。

### Notes

- statix は indented-string 内の `${...}` interpolation を W04 として誤検出するため未配線。`statix.toml` の `disabled_lints` 整備が別 PR の課題。
- shellcheck は git ls-files で tracked `*.sh` のみ対象。Nix-生成 shell script は対象外。
- `nix run .#lint` でローカル動作確認済 (deadnix + shellcheck 両方クリーン)。
