### PR TITLE
feat(mel): declare Minimum Equipment List as essential CI gate (Survivor #6 MVP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Run linters (deadnix + shellcheck)
         timeout-minutes: 5
         run: nix run --accept-flake-config '.#lint'
+      - name: Build MEL (Minimum Equipment List)
+        # MEL は essential 階層: 失敗したら全 PR をブロックする。
+        # 通常 packages の breakage は eval gate のみ (warning 扱い)。
+        timeout-minutes: 15
+        run: nix build --no-link --print-build-logs --accept-flake-config '.#checks.x86_64-linux.mel'
       - name: Evaluate home-manager configuration
         # 完全ビルドは crush 等の go テスト走行で 25min を超える上、
         # 実際にデプロイされるのは aarch64-darwin。eval だけでも cocoapods

--- a/flake.nix
+++ b/flake.nix
@@ -156,6 +156,34 @@
           type = "app";
           program = "${script}/bin/audit";
         };
+      # Minimum Equipment List (Survivor #6 MVP).
+      # 「これさえ動けば仕事継続可能」な最小集合を declarative に固定する。
+      # CI が MEL build を失敗させたら全 PR ブロック (essential)。
+      # 通常 packages の breakage は warning 扱い (現行 CI は eval-only) と
+      # 階層を区別する。USB DR snapshot は次 PR。
+      melFor =
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system overlays;
+            config.allowUnfree = true;
+          };
+        in
+        pkgs.linkFarmFromDrvs "hikae-mel-${system}" (
+          with pkgs;
+          [
+            git
+            gh
+            ripgrep
+            fd
+            jq
+            jj
+            zsh
+            tmux
+            gnupg
+            coreutils
+          ]
+        );
     in
     {
       homeConfigurations."hikae" = forSystem "aarch64-darwin";
@@ -173,6 +201,7 @@
       checks.x86_64-linux = {
         build = (forSystem "x86_64-linux").activationPackage;
         formatting = (treefmtFor "x86_64-linux").config.build.check self;
+        mel = melFor "x86_64-linux";
       };
     };
 }


### PR DESCRIPTION
## Survivor #6 — MEL (Minimum Equipment List)

ideation: docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md (Survivor #6)

### この PR の射程
航空機の MEL に倣い「これさえ動けば仕事継続可能」な最小集合を declarative に固定し、CI で必須 build 階層を essential / nice-to-have に分離する。本 PR は (a) MEL 宣言 + (b) CI essential gate のみ。USB DR snapshot は次 PR。

### Changes

- **`flake.nix`**: `melFor system` を let-block に追加し、`pkgs.linkFarmFromDrvs` で MEL 集合を 1 derivation にまとめる。`checks.x86_64-linux.mel` で flake check に組み込む。
- **`.github/workflows/ci.yml`**: "Build MEL" ステップを追加。`nix build .#checks.x86_64-linux.mel` で MEL closure を実ビルドし、失敗で全 PR ブロック。

### MEL 構成 (10 packages)

| name | 役割 |
|---|---|
| git | バージョン管理の primary |
| gh | GitHub PR 操作 |
| ripgrep | コード検索 |
| fd | ファイル検索 |
| jq | JSON 処理 |
| jj | Jujutsu (補助 VCS、operation log) |
| zsh | shell |
| tmux | terminal multiplexer |
| gnupg | 署名 / 秘密 |
| coreutils | GNU 基本コマンド |

将来追加候補: `1Password CLI` (Brewfile cask)、`nvim` (現状 `code --wait`)、`ssh` (system 提供)。

### Notes / 階層の区別

- 通常 packages (`checks.x86_64-linux.build`) は CI で `nix eval` のみ (完全 build は go テストが 25min 超)。
- MEL は実 build を要求する essential 階層。MEL 構成を増やしすぎると CI 時間が伸びるため、追加は ADR を要求する想定。
- USB DR snapshot は四半期 cron で `nix copy --to file://...` で外部固定する設計を別 PR で。
