### PR TITLE
ci(lint): wire statix with manual_inherit_from disabled in statix.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,9 +103,8 @@
             root="''${PRJ_ROOT:-$(${pkgs.git}/bin/git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")}"
             cd "$root"
 
-            # NOTE: statix は将来追加。現状は indented-string 内の Nix
-            # interpolation を W04 として誤検出するため、別 PR で
-            # statix.toml に disabled_lints を整備してから配線する。
+            echo "==> statix check (config: statix.toml)"
+            ${pkgs.statix}/bin/statix check .
 
             echo "==> deadnix"
             ${pkgs.deadnix}/bin/deadnix --fail .

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,10 @@
+# statix configuration. See https://github.com/oppiliappan/statix
+#
+# `disabled` に書いた lint code はチェックから除外される。
+# 復活させたい時はこのリストから外し、必要なら同 PR でコード側を修正する。
+
+# W04 (manual_inherit_from) は writeShellScriptBin の indented-string 内に
+# 含まれる ${pkgs.X}/bin/Y のような shell-context interpolation を Nix の
+# assignment と誤検出する。flake.nix の audit/lint script で多用される
+# パターンなので一律無効化。
+disabled = ["manual_inherit_from"]


### PR DESCRIPTION
Survivor #4 phase 2 の partial。

#16 で deferred にしていた statix を lint app に追加。`statix.toml` で `manual_inherit_from` (W04) を disable し、indented-string 内の Nix interpolation を assignment と誤検出する偽陽性を抑止。

- `statix.toml` (新規): `disabled = ["manual_inherit_from"]` のみ。
- `flake.nix`: lint app の最初に `statix check .` を追加。

ローカル `nix run .#lint` 通過確認済。