### PR TITLE
feat(hosts): introduce hosts/<host>/ skeleton for multi-host (Survivor #5 足場)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ lib/{ledger,package-registry}.nix  パッケージ ledger のデータ層
 - daily 09:00 launchd で `dotfiles-sync` が `main` 追従。clean tree のみ。
 - weekly GitHub Actions が `flake.lock` を auto-merge PR で更新。
 - 各 sync の結果は `~/.cache/dotfiles-sync/metrics.jsonl` に追記される (`outcome` / `wall_s` / `head_before` / `head_after`)。
-- 2 台目以降は `homeConfigurations.<user>@<host>` matrix が必要 (Survivor #5、未着手)。
+- 2 台目以降の追加: `hosts/<host>/default.nix` を作成し、`flake.nix` の `hosts` attrset に 1 行追加するだけ。`home.nix` は universal な base としてそのまま、host 固有 override (proxy / 別 identity / screenlock など) は host モジュール側に書く。`extraSpecialArgs.host` が各モジュールから参照可能なので必要なら module 内で `if host == "hikae@work" then ... else ...` の分岐も書ける。
 
 ## エージェントが避けるべき変更
 

--- a/flake.nix
+++ b/flake.nix
@@ -52,21 +52,38 @@
         nix-vscode-extensions.overlays.default
       ];
 
-      forSystem =
+      pkgsFor =
         system:
-        let
-          pkgs = import nixpkgs {
-            inherit system overlays;
-            config.allowUnfree = true;
-          };
-        in
+        import nixpkgs {
+          inherit system overlays;
+          config.allowUnfree = true;
+        };
+
+      # Host 表 — 2 台目以降は ./hosts/<host>/default.nix を作って 1 行追加するだけ。
+      # `host` は extraSpecialArgs で各モジュールから参照可能 (host-specific 分岐用)。
+      hosts = {
+        hikae = {
+          system = "aarch64-darwin";
+        };
+      };
+
+      forHost =
+        host:
+        { system, ... }:
         home-manager.lib.homeManagerConfiguration {
-          inherit pkgs;
+          pkgs = pkgsFor system;
           extraSpecialArgs = {
             dotfilesPath = self;
+            inherit host;
           };
-          modules = [ ./home.nix ];
+          modules = [
+            ./home.nix
+            ./hosts/${host}
+          ];
         };
+
+      # 旧 `forSystem` 呼び出しサイトの互換層。primary host (= hikae) を仮定。
+      forSystem = system: forHost "hikae" { inherit system; };
 
       treefmtFor =
         system:
@@ -193,7 +210,7 @@
         );
     in
     {
-      homeConfigurations."hikae" = forSystem "aarch64-darwin";
+      homeConfigurations = nixpkgs.lib.mapAttrs forHost hosts;
 
       formatter = nixpkgs.lib.genAttrs [ "aarch64-darwin" "x86_64-linux" ] (
         system: (treefmtFor system).config.build.wrapper

--- a/hosts/hikae/default.nix
+++ b/hosts/hikae/default.nix
@@ -1,0 +1,10 @@
+# Host-specific module — primary host (`hikae`).
+#
+# 設計: `home.nix` が universal な base、`hosts/<host>/default.nix` が
+# host 固有 override を担う。primary host は base と同一なので空。
+# 例: 業務マシンを増やす時は `hosts/hikae@work/default.nix` を新規作成し、
+# `flake.nix.hosts` 表に追加するだけ。base 側を分岐させない。
+_: {
+  # 例: home.sessionVariables.HTTP_PROXY = "http://corp-proxy:3128";
+  # 例: home.activation.lockScreenAfterIdle = ...;
+}


### PR DESCRIPTION
Survivor #5 の skeleton。実 host 追加なしで multi-host 化に必要な構造だけ整備する。

### Changes

- **`hosts/hikae/default.nix` (新規, 空)**: primary host 用モジュール。base (`home.nix`) と同一なので空。host 固有 override が出てきたらここに書く。
- **`flake.nix`**: `forSystem` を `forHost` (host 名 + system attrset) に置換。`hosts` attrset (`{ hikae = { system = "aarch64-darwin"; }; }`) を single source of truth に。`homeConfigurations = mapAttrs forHost hosts` で host 表から自動展開。`forSystem` は CI の `checks.x86_64-linux.build` 互換用に `forHost "hikae"` のラッパとして残す。`extraSpecialArgs.host` を追加し、各 module から `if host == "hikae@work" then ...` の分岐が書けるように。
- **`AGENTS.md`**: "同期と多重マシン" 節を更新し、2 台目追加手順 (host module 1 ファイル + `hosts` 表 1 行) を明記。

### 次の host 追加例

```nix
# hosts/hikae@work/default.nix
{ ... }: {
  home.sessionVariables.HTTP_PROXY = "http://corp-proxy:3128";
  programs.git.settings.user.email = "work@employer.com";
}
```

`flake.nix` の `hosts` 表に `"hikae@work" = { system = "aarch64-darwin"; };` を 1 行追加すれば `nix run .#homeConfigurations.\"hikae@work\".activationPackage` で適用可能。

### Notes

- 現状 host 表に primary 1 件のみなので機能変更なし (eval/build は完全互換)。
- event-driven `repository_dispatch` 化と `fswatch` 経由の即時 sync は別 PR (実 host が必要)。
- CI matrix も実 host 追加と一緒に。