### PR TITLE
feat(ssh): add opt-in 1Password SSH agent module (Survivor #3 part 1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ lib/{ledger,package-registry}.nix  パッケージ ledger のデータ層
 - **ledger 経由**: `home.packages` を直接書かない。`lib/package-registry.nix` に `mkEntry` で宣言し、purpose (`build`/`edit`/`ops`/`comm`/`observe`/`play`/`util` の 7 値) と `reason` を記す。
 - **逃げ場の明文化**: `Brewfile` に書く時は理由を行コメントで残し、nix 化のトリガーが何かを書く (例: codex CLI の nix 化が ripgrep の brew 削除のトリガー)。
 - **CI ゲート 4 段**: treefmt formatter / home-manager eval / determinism gate / lint (deadnix + shellcheck)。緑にしてから merge。
-- **シークレット**: `~/.aws/credentials` の long-term AKIA 撤去と `1Password CLI + Secure Enclave` への移行が継続中 (Survivor #3)。新規秘密は `op run --` か `direnv` 経由でセッション局所に閉じ、commit しない。
+- **シークレット**: `~/.aws/credentials` の long-term AKIA 撤去と `1Password CLI + Secure Enclave` への移行が継続中 (Survivor #3)。新規秘密は `op run --` か `direnv` 経由でセッション局所に閉じ、commit しない。SSH 認証は `modules/programs/ssh.nix` の `dotfiles.onePasswordSshAgent.enable` を立てれば 1Password agent 経由になる (1Password app と Secure Enclave key の事前用意が前提なので既定 OFF)。
 
 ## 同期と多重マシン
 

--- a/home.nix
+++ b/home.nix
@@ -6,6 +6,7 @@
     ./modules/programs/git.nix
     ./modules/programs/aws.nix
     ./modules/programs/cli-tools.nix
+    ./modules/programs/ssh.nix
     ./modules/programs/zsh.nix
     ./modules/programs/tmux.nix
     ./modules/programs/ghostty.nix

--- a/modules/programs/ssh.nix
+++ b/modules/programs/ssh.nix
@@ -1,0 +1,34 @@
+# SSH config — 1Password SSH agent 統合 (Survivor #3 part 1)
+#
+# 目的: ~/.ssh/id_* に長期秘密を置かず、Secure Enclave に格納された 1Password
+# 管理キーを agent 経由で利用する。enable した時点で:
+#   - 全ホスト宛 SSH の認証を 1Password agent に委譲
+#   - SSH commit signing は signingkey をここでは触らないので別途
+#     `programs.git.settings.user.signingkey` を 1Password 由来 公開鍵に
+#     差し替える必要がある (本 PR は SSH 認証層のみ)
+#
+# 既定 OFF: 1Password app 未インストール環境で IdentityAgent を解決できないと
+# 通常 SSH が壊れるため。`hosts/<host>/default.nix` か任意の module で
+# `dotfiles.onePasswordSshAgent.enable = true;` を立てて opt-in する。
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.dotfiles.onePasswordSshAgent;
+  agentSocket = "${config.home.homeDirectory}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+in
+{
+  options.dotfiles.onePasswordSshAgent.enable = lib.mkEnableOption "use 1Password SSH agent for all SSH hosts";
+
+  config = lib.mkIf cfg.enable {
+    programs.ssh = {
+      enable = true;
+      matchBlocks."*" = {
+        identityAgent = agentSocket;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Survivor #3 (Secret-file Eradication) のうち SSH 認証層の足場。AWS Identity Center 移行は別作業 (ユーザー側 IAM Identity Center 設定が前提)。

### Changes

- **`modules/programs/ssh.nix` (新規)**: `dotfiles.onePasswordSshAgent.enable` option を提供。立てると `programs.ssh.matchBlocks."*".identityAgent` が 1Password agent socket (`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`) を指す。
- **`home.nix`**: imports に `ssh.nix` を追加。
- **`AGENTS.md`**: シークレット節を更新し有効化手順を明記。

### 既定 OFF の理由

1Password app 未インストール環境で IdentityAgent を解決できないと通常 SSH が壊れる。flip 時の前提:

1. 1Password (macOS app) と SSH agent 機能を有効化済
2. Secure Enclave key を 1Password 内で生成
3. 公開鍵を GitHub / 必要なホストに登録
4. `hosts/hikae/default.nix` (or `home.nix`) に `dotfiles.onePasswordSshAgent.enable = true;` を追記

### Notes

- SSH commit signing (`programs.git.settings.user.signingkey`) は本 PR では触らない。1Password 公開鍵への切替は前提が揃った後の別 PR。
- `Brewfile` への 1Password cask 追記は user の install 経路に依存するため pull していない。
