### PR TITLE
fix(vscode): drop ms-vscode.cpptools (removed on darwin in nix-vscode-extensions)

### DIFF
--- a/modules/programs/vscode.nix
+++ b/modules/programs/vscode.nix
@@ -51,7 +51,10 @@ let
     "ms-vscode.anycode-python"
     "ms-vscode.anycode-rust"
     "ms-vscode.anycode-typescript"
-    "ms-vscode.cpptools"
+    # ms-vscode.cpptools は aarch64-darwin / x86_64-darwin で
+    # nix-vscode-extensions の removed list に入っており取得不能。
+    # C/C++ 編集が必要になったら anycode-cpp で代替するか、
+    # 一時的に Brewfile に逃がす。
     "ms-vscode.remote-explorer"
     "ms-vscode.vscode-speech"
     "rust-lang.rust-analyzer"


### PR DESCRIPTION
PR #19 follow-up. `ms-vscode.cpptools` は `nix-vscode-extensions` の `removed.nix` で aarch64-darwin / x86_64-darwin 共に取得不能 (https://github.com/nix-community/nix-vscode-extensions/issues/100)。activation 時に eval error で止まるため除外。

C/C++ 編集が必要になったら `ms-vscode.anycode-cpp` (既に list 内にあり) で代替するか、Brewfile に一時的に逃がす旨をコメントに残した。