### PR TITLE
docs: add operations cookbook + survivor changelog; link from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ lib/{ledger,package-registry}.nix  パッケージ ledger のデータ層
 
 ## 詳細リンク
 
-- ideation: `docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md`
+- 「どう操作するか」: `docs/operations.md` (運用 cookbook、トラブルシュート、ロールバック、新マシン bootstrap)
+- 「何ができたか」: `docs/changelog.md` (Survivor → PR マトリクス、設計判断のサマリ、再考余地、継続条件)
+- 「なぜそう設計したか」: `docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md` (7 Survivor の warrant と rationale)
 - README (人間向け): `README.md`
 - AWS architecture (ADR-0008): `modules/programs/aws.nix` 冒頭コメント

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,59 @@
+# Changelog — Survivor → PR Mapping
+
+`docs/ideation/2026-05-02-secure-fast-lean-dotfiles-ideation.md` で立てた 7 Survivor + 派生作業の着地一覧。各 Survivor は 1 PR で完結とは限らず、phase 単位で複数 PR に分割している。
+
+## Survivor 着地マトリクス
+
+| #   | Survivor                            | 状態            | 主 PR                                                                                                                                                                                                                                                                                             | 残作業 (user-action)                                                                                                                                  |
+| --- | ----------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | 計測駆動 Reproducibility パイプ     | ✅ 全効力       | [#12](https://github.com/HikaruEgashira/dotfiles/pull/12)                                                                                                                                                                                                                                         | trusted-users 設定済 (本セッション)                                                                                                                   |
+| 2   | Package Ledger                      | ✅ Phase 1+2    | [#13](https://github.com/HikaruEgashira/dotfiles/pull/13) [#14](https://github.com/HikaruEgashira/dotfiles/pull/14) [#19](https://github.com/HikaruEgashira/dotfiles/pull/19) [#20](https://github.com/HikaruEgashira/dotfiles/pull/20) [#24](https://github.com/HikaruEgashira/dotfiles/pull/24) | launchd weekly sweep + `expires` enforcement                                                                                                          |
+| 3   | Secret-file Eradication             | △ Part 1        | [#23](https://github.com/HikaruEgashira/dotfiles/pull/23)                                                                                                                                                                                                                                         | (a) AWS IAM Identity Center 移行、(b) 1Password 内で Secure Enclave key 生成・公開鍵登録、(c) `dotfiles.onePasswordSshAgent.enable` を `true` に flip |
+| 4   | Pre-commit Flake Module / lint 集約 | ✅ Phase 1+2    | [#16](https://github.com/HikaruEgashira/dotfiles/pull/16) [#17](https://github.com/HikaruEgashira/dotfiles/pull/17) [#21](https://github.com/HikaruEgashira/dotfiles/pull/21)                                                                                                                     | treefmt polyglot 拡張 (該当言語ファイル発生待ち)、AGENTS.md auto-gen                                                                                  |
+| 5   | GitOps + multi-host matrix          | △ 足場          | [#22](https://github.com/HikaruEgashira/dotfiles/pull/22)                                                                                                                                                                                                                                         | 実 host 追加と `repository_dispatch` 経由 event-driven 化                                                                                             |
+| 6   | MEL (Minimum Equipment List)        | ✅ MVP          | [#18](https://github.com/HikaruEgashira/dotfiles/pull/18)                                                                                                                                                                                                                                         | USB DR snapshot 四半期 cron (外部メディア要件)                                                                                                        |
+| 7   | Gitleaks 一重化                     | ✅ pre-existing | [#11](https://github.com/HikaruEgashira/dotfiles/pull/11)                                                                                                                                                                                                                                         | —                                                                                                                                                     |
+
+## 派生 PR
+
+| PR                                                        | 役割                                                                                                            |
+| --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [#15](https://github.com/HikaruEgashira/dotfiles/pull/15) | `gh auth setup-git` の brew-path hardcode を `home.activation` で declarative 化 + 旧 `~/.gitconfig` 設定パージ |
+| [#14](https://github.com/HikaruEgashira/dotfiles/pull/14) | `coreutils` には `column` が無い → `gawk` printf に置換 (#13 hot-fix)                                           |
+| [#24](https://github.com/HikaruEgashira/dotfiles/pull/24) | `ms-vscode.cpptools` が darwin で removed list 入り → 拡張リストから除外 (#19 hot-fix)                          |
+
+## 設計判断のサマリ
+
+ideation doc に書いていない、実装中に確定した design decisions:
+
+| 判断                                                                                                                                                                | 根拠                                                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Package Ledger は `lib/package-registry.nix` を single source of truth に切り出し、`modules/packages.nix` (consumer) と `apps.<system>.audit` (consumer) が共有する | metadata の二重管理を避けるため。`programs.X.package` は ledger 対象外 (module 単位で audit)                                                  |
+| Lint app は treefmt と分離                                                                                                                                          | treefmt = 整形 (副作用あり)、lint = 検証 (read-only)。同一 entrypoint だと CI gate の意味付けが曖昧になる                                     |
+| `apps.<system>` 経由で audit / lint を提供                                                                                                                          | `nix run .#X` という統一 UX。手元・CI 同一コードで動かせる                                                                                    |
+| Multi-host は `forSystem` を `forHost` に置換 + `hosts` attrset を表に                                                                                              | 表 1 行追加 + `hosts/<host>/default.nix` 1 ファイルで host 増設可能。base (`home.nix`) を分岐させない                                         |
+| 1Password SSH agent は `dotfiles.onePasswordSshAgent.enable` で opt-in                                                                                              | 1Password app 未インストール環境で IdentityAgent を解決できないと SSH 全体が壊れるため既定 OFF                                                |
+| MEL は `linkFarmFromDrvs` で 1 derivation 化                                                                                                                        | `symlinkJoin` だと衝突するファイル (zsh/gnupg 等) で fail する。linkFarmFromDrvs は名前衝突を pname で回避                                    |
+| Determinism gate は eval 段階のみ                                                                                                                                   | build determinism (output hash 一致) は CI 完全 build を要する。現状 CI は eval-only なので eval 段階の drvPath 安定性 (impurity 検出) に絞る |
+| credential.helper 修正は `home.activation.purgeStaleGhCredentialHelper` で旧設定を unset                                                                            | `~/.gitconfig` (legacy) は HM-managed `~/.config/git/config` を override するため、旧設定を残したままだと新設定が無効化される                 |
+| statix の `manual_inherit_from` (W04) を一律 disable                                                                                                                | `writeShellScriptBin` 内 indented-string の `${pkgs.X}` を assignment と誤検出するため。`statix.toml` で project-wide に抑制                  |
+
+## 設計判断のうち再考余地があるもの
+
+将来見直すかもしれない選択 (今は確定だが anti-pattern 化したら revisit):
+
+- **VS Code 拡張は `vscode-marketplace` のみ**: `open-vsx` を fallback に使う設計はしていない。MS proprietary な拡張 (`cpptools` 等) を諦めたら open-vsx 切替を検討。
+- **MEL は固定 10 packages**: ADR を要求する閉じた集合だが、`vim` / `nvim` / `1password-cli` を加えるか議論余地あり。
+- **`hosts` 表に system を持たせている**: 全 host が `aarch64-darwin` なら冗長。逆に Linux host を増やすなら今の構造のまま使える。
+- **lint app と CI の duplication**: `nix run .#lint` と `.github/workflows/ci.yml` の `Run linters` ステップは同じことをする。CI 側を `nix run .#lint` 1 行に絞っているが、CI 専用検査 (例: PR 件数しきい値) を増やすなら別 entrypoint が要る。
+
+## 今後の Survivor 継続条件
+
+| Survivor                     | 次のアクションが取れる条件                                   |
+| ---------------------------- | ------------------------------------------------------------ |
+| #2 phase 3 (launchd sweep)   | `expires` を実エントリに振る運用合意ができたら               |
+| #3 完全 (AKIA 撤去)          | AWS account 側で IAM Identity Center が設定されたら          |
+| #4 (treefmt polyglot)        | Python / TS / Go / Lua いずれかのファイルがリポに発生したら  |
+| #4 (AGENTS.md auto-gen)      | module 数が今後 2 倍以上に増え、手書きが追従できなくなったら |
+| #5 (event-driven multi-host) | 2 台目 host が物理的に増えたら                               |
+| #6 (USB DR snapshot)         | 外部メディア (USB or Time Machine drive) の所在が決まったら  |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,184 @@
+# Operations Cookbook
+
+`~/dotfiles` の運用レシピ集。「どう書くか」は `AGENTS.md`、「なぜそう設計したか」は `docs/ideation/` と各 PR description、「何ができたか」は `docs/changelog.md`。本ドキュメントは「どう操作するか」のみを扱う。
+
+## 1. 日常運用
+
+| やりたいこと  | コマンド                                                        | 備考                                                                 |
+| ------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| 設定を反映    | `nix run ~/dotfiles#homeConfigurations.hikae.activationPackage` | 冪等。`--accept-flake-config` は trusted-users 設定後は不要          |
+| ledger 棚卸し | `nix run ~/dotfiles#audit`                                      | purpose 別集計 + 全 entry 表 + expires 切れ件数                      |
+| 静的検査      | `nix run ~/dotfiles#lint`                                       | statix + deadnix + shellcheck (CI と同一)                            |
+| 整形          | `nix fmt ~/dotfiles`                                            | nixfmt + prettier + shfmt                                            |
+| flake gate    | `nix flake check ~/dotfiles --accept-flake-config`              | formatter + eval + apps + checks                                     |
+| inputs 更新   | `nix flake update ~/dotfiles`                                   | 週次 GitHub Actions が PR を auto-merge する。手動更新はめったに不要 |
+| 同期実績      | `tail -n5 ~/.cache/dotfiles-sync/metrics.jsonl`                 | `outcome / wall_s / head_before / head_after`                        |
+
+## 2. 何かを追加する
+
+### 2.1 新しい `home.packages` を足す
+
+1. `lib/package-registry.nix` の `cross` (or `darwinOnly`) に追加:
+   ```nix
+   (mkEntry { pkg = pkgs.<NAME>; purpose = "build"; reason = "<one line>"; })
+   ```
+2. `purpose` は `build` / `edit` / `ops` / `comm` / `observe` / `play` / `util` の 7 値固定。新カテゴリは `lib/ledger.nix` の `purposes` 修正と ADR 起票が要る。
+3. `nix run .#audit` で出てくれば成功。
+
+### 2.2 新しい program を足す (設定が必要なもの)
+
+1. `modules/programs/<NAME>.nix` を作成。
+2. `home.nix` の `imports` にパスを追加。
+3. `nix flake check --accept-flake-config` で eval 通過を確認。
+
+### 2.3 新しい VS Code 拡張を足す
+
+1. `modules/programs/vscode.nix` の `extensionIds` に `"<publisher>.<name>"` を追加 (名前順)。
+2. `nix flake check` で eval 通過を確認。`throw "vscode extension not found ..."` が出たら overlay にその拡張がない (新規すぎる / removed list) — `nix-vscode-extensions` の `removed.nix` を確認して anycode 等で代替するか Brewfile 一時退避。
+3. `Brewfile` への `vscode "..."` 追加は CI で fail するので避ける。
+
+### 2.4 新しい host (2 台目以降) を足す
+
+1. `hosts/<HOST>/default.nix` を新規作成。host 固有の override (proxy / 別 identity / screenlock) を書く。
+2. `flake.nix` の `hosts` attrset に 1 行追加:
+   ```nix
+   hosts = {
+     hikae = { system = "aarch64-darwin"; };
+     "<HOST>" = { system = "aarch64-darwin"; };
+   };
+   ```
+3. 新 host で `nix run github:HikaruEgashira/dotfiles#homeConfigurations.<HOST>.activationPackage`。
+
+### 2.5 nixpkgs に無い GUI / kext を足す
+
+1. `Brewfile` に `cask "<NAME>"` で追加。
+2. 直前のコメント行に nix 化できない理由を残す (例: `# nixpkgs broken`, `# kext required`)。
+3. nix 化できるようになったら Brewfile から削除し `lib/package-registry.nix` に移す。
+
+## 3. オプトイン機能を有効化する
+
+### 3.1 cachix substituter を実効化 (Survivor #1)
+
+1 度だけ:
+
+```bash
+echo 'extra-trusted-users = @admin' | sudo tee -a /etc/nix/nix.custom.conf
+sudo launchctl kickstart -k system/systems.determinate.nix-daemon
+```
+
+確認:
+
+```bash
+nix show-config | grep '^trusted-users'   # → root @admin
+```
+
+以降の activation は `nix-community.cachix.org` から fetch する。
+
+### 3.2 1Password SSH agent (Survivor #3 part 1)
+
+前提:
+
+- 1Password app + SSH agent を有効化
+- 1Password 内で Secure Enclave key を生成
+- 公開鍵を GitHub などに登録
+
+`hosts/hikae/default.nix` (or 任意の module) に追加:
+
+```nix
+{ ... }: {
+  dotfiles.onePasswordSshAgent.enable = true;
+}
+```
+
+activation 後、`~/.ssh/config` に `IdentityAgent ~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock` が出れば成功。`ssh -T git@github.com` で auth が通れば実体化済。
+
+## 4. トラブルシュート
+
+### 4.1 activation が失敗した
+
+1. エラーメッセージで「extension <X> has been removed on aarch64-darwin」→ `nix-vscode-extensions` の removed list 該当。`vscode.nix` から削除して再 activation。
+2. eval で `infinite recursion` → 直近の module 編集を疑う。`git diff HEAD~1` で範囲を絞る。
+3. 完全に動かなくなった → `home-manager generations` で旧 gen を確認し、`/nix/store/<HASH>-home-manager-generation/activate` を直接実行で巻き戻し。
+
+### 4.2 CI が落ちた
+
+| 失敗ステップ                          | 主因 / 対応                                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `Run formatter check`                 | `nix fmt` を走らせて再 commit                                                                    |
+| `Lint Brewfile (no vscode entries)`   | `Brewfile` から `vscode "..."` 行を撤去し `modules/programs/vscode.nix` の `extensionIds` に追加 |
+| `Run linters (deadnix + shellcheck)`  | `nix run .#lint` をローカルで叩いてエラーを再現、修正                                            |
+| `Evaluate home-manager configuration` | platform-mismatch (darwin-only pkg を `cross` に入れた等)。`darwinOnly` に移す                   |
+| `Eval determinism gate`               | `builtins.currentTime` / IFD など impurity が混入した。当該 commit を切り戻し                    |
+| `Build MEL`                           | MEL essential pkg のいずれかが破損。nixpkgs を一時 pin or 該当 pkg を MEL から外す ADR           |
+
+### 4.3 `git push` が `Device not configured` で fail する
+
+`~/.gitconfig` の credential.helper が brew 由来 path に hardcode された旧症状 (PR #15 で修正済)。再発したら:
+
+```bash
+nix run ~/dotfiles#homeConfigurations.hikae.activationPackage
+```
+
+で `home.activation.purgeStaleGhCredentialHelper` が走り、HM-managed `~/.config/git/config` の helper を再生する。それでも直らない場合:
+
+```bash
+git config --file ~/.gitconfig --unset-all credential.https://github.com.helper
+git config --file ~/.gitconfig --unset-all credential.https://gist.github.com.helper
+```
+
+### 4.4 dotfiles-sync が動いていない
+
+```bash
+launchctl print gui/$(id -u)/dev.egahika.dotfiles-sync   # state 確認
+launchctl kickstart -k gui/$(id -u)/dev.egahika.dotfiles-sync   # 強制実行
+tail -n20 ~/.cache/dotfiles-sync/{log,err}                # 出力確認
+tail -n5 ~/.cache/dotfiles-sync/metrics.jsonl             # 直近結果
+```
+
+## 5. 緊急時 / ロールバック
+
+### 5.1 直近の HM 適用を巻き戻す
+
+```bash
+home-manager generations | head -3            # 直近 gen を確認
+/nix/store/<PREVIOUS-HASH>-home-manager-generation/activate
+```
+
+`<PREVIOUS-HASH>` は `home-manager generations` の 2 行目 (1 つ前) の store path。
+
+### 5.2 1 つ前の commit に main を戻す
+
+```bash
+git -C ~/dotfiles fetch git@github.com:HikaruEgashira/dotfiles.git main
+git -C ~/dotfiles revert <BAD_COMMIT> -m 1     # PR の merge commit なら -m 1
+git -C ~/dotfiles push                          # CI 緑で auto-merge
+```
+
+### 5.3 cachix substituter trust を撤回
+
+```bash
+sudo sed -i '' '/^extra-trusted-users = @admin$/d' /etc/nix/nix.custom.conf
+sudo launchctl kickstart -k system/systems.determinate.nix-daemon
+```
+
+これで PR #12 の効果のみ無効化、他の改善は影響なし。
+
+## 6. 新マシン bootstrap (将来の自分のため)
+
+```bash
+# 1) Determinate Nix を入れる (curl オフィシャル installer)
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install
+
+# 2) trusted-users を即足す (Survivor #1 を最初から効かせる)
+echo 'extra-trusted-users = @admin' | sudo tee -a /etc/nix/nix.custom.conf
+sudo launchctl kickstart -k system/systems.determinate.nix-daemon
+
+# 3) リポを clone & apply
+gh repo clone HikaruEgashira/dotfiles ~/dotfiles
+nix run ~/dotfiles#homeConfigurations.hikae.activationPackage --accept-flake-config
+
+# 4) brew 部分 (kext / GUI / vscode 以外の cask)
+brew bundle --file=~/dotfiles/Brewfile
+
+# 5) 1Password SSH agent を opt-in する場合は §3.2 を実行
+```


### PR DESCRIPTION
3 つのドキュメントレイヤを 1 PR で整える。

### 追加

- **`docs/operations.md` (新規)**: 運用 cookbook。日常運用のコマンド表 / 何かを追加する手順 (package, program, VS Code 拡張, host, brew cask) / オプトイン機能の有効化 (cachix substituter, 1Password SSH agent) / トラブルシュート (activation 失敗、CI fail パターン別対応、credential helper 再発時、dotfiles-sync 不動時) / ロールバック / 新マシン bootstrap の 1 ページ参照。

- **`docs/changelog.md` (新規)**: ideation 7 Survivor + 派生 PR の着地マトリクス。各 Survivor について状態 / 主 PR / 残作業 (user-action) を集約し、ideation doc に書いていない実装中確定の design decisions と「再考余地」「今後の継続条件」を併記。

- **`AGENTS.md`**: 詳細リンク節で 3 ドキュメントの役割分担を明記:
  - 「どう操作するか」 → `docs/operations.md`
  - 「何ができたか」 → `docs/changelog.md`
  - 「なぜそう設計したか」 → `docs/ideation/...`

### 役割分担の意図

- `AGENTS.md` = 入口 (5 行レイアウト、規約、避けるべき変更)
- `docs/operations.md` = 運用 (再現可能な手順)
- `docs/changelog.md` = 結果 (PR と決定の archeology)
- `docs/ideation/...` = 設計 (warrant と rationale)

各ドキュメントの責任を分け、どこに書くべきかが迷いにくい状態にする。

### 検証

- `nix fmt` で 4 ファイル整形 (treefmt が markdown を整える)
- `nix run .#lint` 通過 (deadnix + shellcheck はドキュメントを対象にしないので影響なし)
