### PR TITLE
feat(claude): bring .mcp.json under home-manager

### DIFF
--- a/modules/programs/claude.nix
+++ b/modules/programs/claude.nix
@@ -1,6 +1,7 @@
 { lib, pkgs, ... }:
 let
   managed = [
+    ".mcp.json"
     "settings.json"
     "CLAUDE.md"
     "RTK.md"

--- a/modules/programs/claude/.mcp.json
+++ b/modules/programs/claude/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sisakuintel": {
+      "type": "http",
+      "url": "https://gnz50e1eu9.execute-api.ap-northeast-1.amazonaws.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
After confirming sisakuintel implements MCP OAuth 2.0 (RFC 9728 +
RFC 8414 + RFC 7591 DCR + PKCE S256) end-to-end, the hand-pasted
`Authorization: Bearer gho_...` header was no longer needed. Removing
it lets Claude Code drive the standard 401 -> metadata -> DCR ->
authorization_code flow and cache the resulting access token in the
OS keychain, eliminating the long-lived secret from the on-disk
config.

With no secret remaining, .mcp.json becomes declaratively managed
alongside the rest of the Claude config.
