### PR TITLE
revert(claude): drop dormant .mcp.json

### DIFF
--- a/modules/programs/claude.nix
+++ b/modules/programs/claude.nix
@@ -1,7 +1,6 @@
 { lib, pkgs, ... }:
 let
   managed = [
-    ".mcp.json"
     "settings.json"
     "CLAUDE.md"
     "RTK.md"

--- a/modules/programs/claude/.mcp.json
+++ b/modules/programs/claude/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "sisakuintel": {
-      "type": "http",
-      "url": "https://gnz50e1eu9.execute-api.ap-northeast-1.amazonaws.com/mcp"
-    }
-  }
-}


### PR DESCRIPTION
Empirical check showed Claude Code never reads ~/.claude/.mcp.json:

  $ claude mcp list
  No MCP servers configured.

  $ jq '.projects[].mcpServers // {} | keys' ~/.claude.json
  (all empty)

  $ jq '.mcpServers // "none"' ~/.claude.json
  "none"

Claude Code's user-scope MCP registry lives in ~/.claude.json under
.mcpServers / .projects[].mcpServers, populated via `claude mcp add`.
The standalone ~/.claude/.mcp.json file at user level was never wired
into any code path -- the previously hardcoded bearer token was
inert all along (the leak vector is the on-disk + transcript
exposure, not request traffic).

Declaratively managing a file no one reads is dead weight. Re-add
sisakuintel via `claude mcp add --transport http --scope user
sisakuintel <url>` the day it's actually needed; OAuth DCR + PKCE
will handle the credential automatically.
