### PR TITLE
fix(claude): point say hooks at the mise shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,15 @@ lib/{ledger,package-registry}.nix  パッケージ ledger のデータ層
 
 ## 何をどこに書くか
 
-| やりたいこと                       | 置き場所                                                               |
-| ---------------------------------- | ---------------------------------------------------------------------- |
-| `pkgs.<name>` だけで足りる package | `lib/package-registry.nix` (`mkEntry { pkg; purpose; reason; }`)       |
-| 設定が要る program                 | `modules/programs/<name>.nix` を新規作成、`home.nix` に `imports` 追加 |
-| GUI / kext / nixpkgs に無いもの    | `Brewfile` (理由をコメントで残す)                                      |
-| CLI 補助・チートシート             | `modules/settings/<topic>.{sh,md}`                                     |
-| ideation / 設計                    | `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`                         |
-| ADR / 解決策                       | `docs/solutions/<problem-type>/<id>.md` (未整備)                       |
+| やりたいこと                       | 置き場所                                                                                                                                 |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `pkgs.<name>` だけで足りる package | `lib/package-registry.nix` (`mkEntry { pkg; purpose; reason; }`)                                                                         |
+| 設定が要る program                 | `modules/programs/<name>.nix` を新規作成、`home.nix` に `imports` 追加                                                                   |
+| GUI / kext / nixpkgs に無いもの    | `Brewfile` (理由をコメントで残す)                                                                                                        |
+| CLI 補助・チートシート             | `modules/settings/<topic>.{sh,md}`                                                                                                       |
+| Claude Code のユーザー設定         | `modules/programs/claude/<file>` (settings.json / CLAUDE.md / hooks 等); MCP は `claude mcp add --scope user` で `~/.claude.json` に登録 |
+| ideation / 設計                    | `docs/ideation/YYYY-MM-DD-<topic>-ideation.md`                                                                                           |
+| ADR / 解決策                       | `docs/solutions/<problem-type>/<id>.md` (未整備)                                                                                         |
 
 ## 実行可能エントリポイント
 

--- a/modules/programs/claude/hooks/say_on_stop.py
+++ b/modules/programs/claude/hooks/say_on_stop.py
@@ -2,8 +2,11 @@
 """Stop hook: last line of assistant response を say コマンドで発話する"""
 
 import json
+import os
 import subprocess
 import sys
+
+SAY_BIN = os.path.expanduser("~/.local/share/mise/shims/say")
 
 
 def main():
@@ -27,10 +30,7 @@ def main():
 
     last_line = lines[0]
 
-    subprocess.run(
-        ["/Users/hikae/ghq/github.com/HikaruEgashira/say/say", last_line],
-        check=False,
-    )
+    subprocess.run([SAY_BIN, last_line], check=False)
 
 
 if __name__ == "__main__":

--- a/modules/programs/claude/settings.json
+++ b/modules/programs/claude/settings.json
@@ -73,7 +73,7 @@
           },
           {
             "type": "command",
-            "command": "/Users/hikae/.local/share/mise/installs/github-hikaru-egashira-say/v0.2.0/say hook",
+            "command": "/Users/hikae/.local/share/mise/shims/say hook",
             "async": true
           }
         ]


### PR DESCRIPTION
Two say invocations were misaddressed:

- settings.json Stop hook pinned the install path of say@v0.2.0, so
  any mise bump (manual or via .tool-versions) silently broke the
  hook.
- say_on_stop.py shelled out to ~/ghq/.../say, which doesn't exist
  on this host; subprocess.run(check=False) hid the FileNotFoundError
  so the read-aloud feature was silently no-op for the entire life
  of the hook.

Both now go through ~/.local/share/mise/shims/say. The shim is a
stable absolute path; mise resolves the active version behind it,
matching the existing convention for other mise-managed CLIs.

Also adds a row to AGENTS.md describing where Claude Code user
config belongs and the proper MCP registration path.
