### PR TITLE
fix(herdr): Yui voiceを端末へ適用

### DIFF
--- a/modules/programs/herdr.nix
+++ b/modules/programs/herdr.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 let
-  sayHookRevision = "a595d2b4a2b698536ca9eb1d141807efa42bd743";
-  sayHookVersion = "v0.4.0";
+  sayHookRevision = "6bfb4269a9b626847433f11a1549a1688abcded0";
+  sayHookVersion = "v0.4.1";
 in
 {
   home = {
@@ -28,7 +28,8 @@ in
       ".config/herdr/plugins/config/hikaruegashira.say-hook/.env" = {
         text = ''
           SAY_BIN=$HOME/.local/share/mise/installs/github-hikaru-egashira-say-hook/${sayHookVersion}/say-hook
-          export ELEVENLABS_VOICE_ID=JBFqnCBsd6RMkjVDRZzb
+          ELEVENLABS_VOICE_ID=fUjY9K2nAIwlALOwSiwc
+          ELEVENLABS_VOICE_NAME='Yui - Japanese girl female Anime voice'
         '';
         force = true;
       };
@@ -55,6 +56,7 @@ in
           || PATH="${pkgs.git}/bin:$PATH" $DRY_RUN_CMD ${pkgs.herdr}/bin/herdr plugin install HikaruEgashira/say-hook/herdr --ref ${sayHookRevision} --yes
 
         $DRY_RUN_CMD ${pkgs.herdr}/bin/herdr plugin action invoke install-claude-hook --plugin hikaruegashira.say-hook
+        $DRY_RUN_CMD ${pkgs.herdr}/bin/herdr plugin action invoke check --plugin hikaruegashira.say-hook
       '';
     };
   };


### PR DESCRIPTION
## 概要
- say-hookをv0.4.1 / `6bfb426`へ更新
- HerdrのvoiceをGeorgeからYuiへ復旧
- IDと期待voice名を一緒に宣言
- Home Manager activationで非発話`check`を実行し、取り違えを失敗させる

## 検証
- `nix fmt modules/programs/herdr.nix`
- `nix flake check`

## 反映後の確認
- Herdr plugin `check`でYuiのID・名前・属性を確認
- Herdr plugin `test`で実音声を確認